### PR TITLE
Add DELETE function to default_client

### DIFF
--- a/default_client.go
+++ b/default_client.go
@@ -16,6 +16,7 @@ var Defaults func(Map) *HttpClient
 var Begin func() *HttpClient
 var Do func(string, string, map[string]string, io.Reader)(*Response, error)
 var Get func(string, map[string]string)(*Response, error)
+var Delete func(string, map[string]string)(*Response, error)
 var Head func(string, map[string]string)(*Response, error)
 var Post func(string, map[string]string)(*Response, error)
 var PostMultipart func(string, map[string]string)(*Response, error)
@@ -34,6 +35,7 @@ func init() {
     Begin = defaultClient.Begin
     Do = defaultClient.Do
     Get = defaultClient.Get
+    Delete = defaultClient.Delete
     Head = defaultClient.Head
     Post = defaultClient.Post
     PostMultipart = defaultClient.PostMultipart


### PR DESCRIPTION
Hi again,

Looks like I need to add the new "Delete" function to `default_client.go` in order for it to be available as `httpclient.Delete`. This PR adds that change.