### PR TITLE
fixed a bug - transport & jar reuse logic was inverted

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -467,12 +467,12 @@ func (this *HttpClient) WithOption(k int, v interface{}) *HttpClient {
 	this.oneTimeOptions[k] = v
 
 	// Conditions we cann't reuse the transport.
-	if !hasOption(k, transportOptions) {
+	if hasOption(k, transportOptions) {
 		this.reuseTransport = false
 	}
 
 	// Conditions we cann't reuse the cookie jar.
-	if !hasOption(k, jarOptions) {
+	if hasOption(k, jarOptions) {
 		this.reuseJar = false
 	}
 


### PR DESCRIPTION
Hi, I noticed setting OPT_PROXY after some fetches without a proxy had no effect so I dug into the sources. What I found was the logic of reuse was inverted. Here is the patch.