### PR TITLE
transport.Dial is deprecated, use transport.DialContext instead

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -218,7 +218,7 @@ func prepareTransport(options map[int]interface{}) (http.RoundTripper, error) {
 		connectTimeoutMS = timeoutMS
 	}
 
-	transport.Dial = func(network, addr string) (net.Conn, error) {
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 		var conn net.Conn
 		var err error
 		if connectTimeoutMS > 0 {


### PR DESCRIPTION
I believe this should be a simple update. Let me know if not.