### PR TITLE
Fix README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,11 @@ res.Body.Close()
 
 // ToString
 res, err = httpclient.Get("http://google.com")
-bodyString,err := res.ToString()
+bodyString, err := res.ToString()
 
 // ReadAll
 res, err = httpclient.Get("http://google.com")
-bodyBytes := res.ReadAll()
+bodyBytes, err := res.ReadAll()
 ```
 
 ### Handle Cookies


### PR DESCRIPTION
Fix example in README. `Response.ReadAll` returns `([]byte, error)`.